### PR TITLE
Update guides-and-tips.mdx

### DIFF
--- a/src/docs/guides-and-tips/guides-and-tips.mdx
+++ b/src/docs/guides-and-tips/guides-and-tips.mdx
@@ -21,8 +21,6 @@ To keep the generated DOM inside the Web Component:
 
 Example
 ```jsx
-const domRef = React.createRef();
-
 const [anchorEl, setAnchorEl] = React.useState(null);
 const handlePopoverClick = event => {
     setAnchorEl(event.currentTarget);
@@ -59,7 +57,7 @@ To keep the generated DOM inside the Web Component:
 
 Example
 ```jsx
-const domRef = React.createRef();
+const domRef = React.useRef();
 
 return (
   <div>


### PR DESCRIPTION
- Deleted two const with the same name in the Popover example, it is just needed the useRef one.
- Change to useRef instead of createRef to get the reference of the DOM.